### PR TITLE
Add support for datetime strings within load test parameters to be specified in ISO 8601 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ orchestrator-past:
     test_params: '{
                     "base_url": "http://www.mywebsite.com",
                     "rate": 100,
-                    "replay_start_time": "2018-4-2-15-40",
+                    "replay_start_time": "2018-08-06T13:30",
                     "loop_duration": 60,
                     "identifier": "oss"
                 }'
@@ -66,8 +66,9 @@ orchestrator-past:
   #                       no requests will be sent in the load test.
   # "loop_duration" - This is an integer value, denominated in minutes.
   #                   It is how long the replay period will be, starting from the time specified in "replay_start_time"
-  #                   For example, if "replay_start_time" = "2018-1-1-10-0" and "loop_duration" = 60,
-  #                   then it will replay traffic from 2018-1-1-10-0 to 2018-1-1-11-0
+  #                   For example, if "replay_start_time" = "2018-08-06T13:30" and "loop_duration" = 60,
+  #                   then it will replay traffic from 2018-08-06T13:30 to 2018-08-06T14:30
+  #                   (ie. replay traffic from 2018-08-06 1:30PM to 2:30PM)
   # "identifier" - This is an identifier that is used when tagging CloudWatch metrics. Editing it is optional.
   # "timezone" - Timezone the replay_start_time is in. Accepts pytz timezone names like "US/Pacific" or "UTC"
 ```

--- a/shadowreader/classes/mytime.py
+++ b/shadowreader/classes/mytime.py
@@ -253,10 +253,12 @@ class MyTime:
             "%Y-%m-%dT%H:%M:%S",
             "%Y-%m-%dT%H:%M:%S.%f",
             "%Y-%m-%dT%H:%M:%S.%fZ",
+            "%Y-%m-%dT%H:%M:%S.%f%Z",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
         ]
-        for myformat in formats:
+        for f in formats:
             try:
-                replay_start_time = datetime.strptime(formatted_time, myformat)
+                replay_start_time = datetime.strptime(formatted_time, f)
                 kwargs = {
                     "year": replay_start_time.year,
                     "month": replay_start_time.month,
@@ -275,7 +277,9 @@ class MyTime:
         """ Strip timezone from ISO format string
             Ex: '2018-08-03T08:30:00.000+10:00' => '2018-08-03T08:30:00.000'
         """
-        pattern = r"[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}.[\d]+(\+|-)[\d]{2}:[\d]{2}"
+        pattern = (
+            r"[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}.[\d]+(\+|-)[\d]{2}:[\d]{2}"
+        )
         match = re.match(pattern, formatted_time)
         if match:
             return formatted_time[:-6]
@@ -286,4 +290,5 @@ class MyTime:
         """ Format as string in format expected in the severless.yml test parameters.
         Example formatting: 2018-6-19-0-0
         """
-        return self.dt.strftime('%Y-%m-%d-%H-%M')
+        return self.dt.strftime("%Y-%m-%d-%H-%M")
+

--- a/shadowreader/classes/mytime.py
+++ b/shadowreader/classes/mytime.py
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 from datetime import datetime, timedelta
 from functools import total_ordering
 from typing import Union
+import re
 
 from pytz import timezone, utc
 
@@ -217,22 +218,69 @@ class MyTime:
         return hasattr(other, "dt") and hasattr(other, "epoch")
 
     @staticmethod
-    def set_to_replay_start_time_env_var(lambda_env_var, tzinfo) -> 'MyTime':
-        replay_start_time = list(map(int, lambda_env_var.split('-')))
+    def set_to_replay_start_time_env_var(lambda_env_var: str, tzinfo: str) -> "MyTime":
+        """ First, try parsing the time as ISO format.
+        If that fails, fall back to legacy format which is: year-month-day-hour-minute
+        ex: "2018-6-28-8-40"
+        """
+        lambda_env_var = MyTime._strip_timezone_from_isoformat(lambda_env_var)
+        replay_start_time = MyTime._try_isoformat(lambda_env_var, tzinfo)
+        if replay_start_time:
+            return replay_start_time
+        else:
+            replay_start_time = list(map(int, lambda_env_var.split("-")))
 
-        if len(replay_start_time) != 5:
-            raise InvalidLambdaEnvVarError(
-                f'replay_start_time value was not valid: {lambda_env_var}')
+            if len(replay_start_time) != 5:
+                raise InvalidLambdaEnvVarError(
+                    f"replay_start_time value was not valid: {replay_start_time}"
+                )
 
-        kwargs = {
-            'year': replay_start_time[0],
-            'month': replay_start_time[1],
-            'day': replay_start_time[2],
-            'hour': replay_start_time[3],
-            'minute': replay_start_time[4],
-            'tzinfo': tzinfo
-        }
-        return MyTime(**kwargs)
+            kwargs = {
+                "year": replay_start_time[0],
+                "month": replay_start_time[1],
+                "day": replay_start_time[2],
+                "hour": replay_start_time[3],
+                "minute": replay_start_time[4],
+                "tzinfo": tzinfo,
+            }
+            return MyTime(**kwargs)
+
+    @staticmethod
+    def _try_isoformat(formatted_time: str, tzinfo: str) -> Union["MyTime", None]:
+        """ Try parsing formatted_time as ISO format """
+        formats = [
+            "%Y-%m-%dT%H:%M",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S.%fZ",
+        ]
+        for myformat in formats:
+            try:
+                replay_start_time = datetime.strptime(formatted_time, myformat)
+                kwargs = {
+                    "year": replay_start_time.year,
+                    "month": replay_start_time.month,
+                    "day": replay_start_time.day,
+                    "hour": replay_start_time.hour,
+                    "minute": replay_start_time.minute,
+                    "tzinfo": tzinfo,
+                }
+                return MyTime(**kwargs)
+            except ValueError as e:
+                pass
+        return None
+
+    @staticmethod
+    def _strip_timezone_from_isoformat(formatted_time: str) -> str:
+        """ Strip timezone from ISO format string
+            Ex: '2018-08-03T08:30:00.000+10:00' => '2018-08-03T08:30:00.000'
+        """
+        pattern = r"[\d]{4}-[\d]{2}-[\d]{2}T[\d]{2}:[\d]{2}:[\d]{2}.[\d]+(\+|-)[\d]{2}:[\d]{2}"
+        match = re.match(pattern, formatted_time)
+        if match:
+            return formatted_time[:-6]
+        else:
+            return formatted_time
 
     def format_as_env_var(self) -> str:
         """ Format as string in format expected in the severless.yml test parameters.

--- a/shadowreader/serverless.example.yml
+++ b/shadowreader/serverless.example.yml
@@ -83,8 +83,8 @@ functions:
       test_params: '{
                       "base_url": "http://your_base_url.com",
                       "rate": 0,
-                      "replay_start_time": "2018-5-7-17-30",
-                      "loop_duration": 1,
+                      "replay_start_time": "2018-08-06T13:30",
+                      "loop_duration": 60,
                       "identifier": "oss"
                     }'
       timezone: US/Pacific
@@ -102,8 +102,9 @@ functions:
       #                       it will not run.
       # "loop_duration" - This is an integer value, denominated in minutes.
       #                   It is how long the replay period will be, starting from the time specified in "replay_start_time"
-      #                   For example, if "replay_start_time" = "2018-1-1-10-0" and "loop_duration" = 60,
-      #                   then it will replay traffic from 2018-1-1-10-0 to 2018-1-1-11-0
+      #                   For example, if "replay_start_time" = "2018-08-06T13:30" and "loop_duration" = 60,
+      #                   then it will replay traffic from 2018-08-06T13:30 to 2018-08-06T14:30
+      #                   (ie. replay traffic from 2018-08-06 1:30PM to 2:30PM)
       # "identifier" - This is an identifier that is used when tagging CloudWatch metrics. Editing it is optional.
       # "timezone" - Timezone the replay_start_time is in. Accepts pytz timezone names like "US/Pacific" or "UTC"
       # >>> import pytz

--- a/shadowreader/tests/unit/test_mytime.py
+++ b/shadowreader/tests/unit/test_mytime.py
@@ -103,9 +103,32 @@ def test_init_from_replay_start_time():
     replay_start_time = "2018-2-5-18-15"  # epoch time for 2018-2-5, 6:15PM PST is 1517883300
     mytime = MyTime.set_to_replay_start_time_env_var(replay_start_time,
                                                      timezone('US/Pacific'))
-    print(mytime)
-    print(mytime.epoch)
     assert mytime.epoch == 1517883300
+
+
+def test_init_from_replay_start_time_w_isoformat():
+    # Test that ISO 8601 formatted times are parsed correctly
+    # Test for Thursday, August 2, 2018 12:30:00 AM GMT-07:00 DST
+    replay_start_times = [
+        "2018-08-02T00:30",
+        "2018-08-02T00:30:40",
+        "2018-08-02T00:30:40.873460",
+        "2018-08-02T00:30:40.873460-07:00",
+        "2018-08-02T00:30:40.873Z",
+        "2018-08-02T00:30:40.873+10:00",
+    ]
+    for t in replay_start_times:
+        mytime = MyTime.set_to_replay_start_time_env_var(t, timezone("US/Pacific"))
+        assert mytime.epoch == 1533195000
+
+
+def test_strip_timezone_from_isoformat():
+    # Test that ISO 8601 formatted times with timezone
+    # have the timezone part removed
+    times = ["2018-08-03T08:30:00.00011+10:00" "2018-08-03T13:52:19.235608-07:00"]
+    for time in times:
+        time_stripped = MyTime._strip_timezone_from_isoformat(time)
+        assert time[:-6] == time_stripped
 
 
 def test_add_timedelta():
@@ -117,9 +140,6 @@ def test_add_timedelta():
             minute=0,
             tzinfo=timezone('US/Pacific'))
     mytime_plus_65_mins = mytime.add_timedelta(minutes=65)
-    print(mytime)
-    print(mytime.epoch)
-    print(mytime_plus_65_mins.tzinfo)
     assert (mytime.epoch + 60 * 65) == mytime_plus_65_mins.epoch
     assert str(mytime_plus_65_mins.tzinfo) == 'US/Pacific'
 

--- a/shadowreader/tests/unit/test_orchestrator.py
+++ b/shadowreader/tests/unit/test_orchestrator.py
@@ -20,8 +20,8 @@ from libs import orchestrator
 
 def test_init_apps_from_test_params():
     defaults = {
-        'apps_to_test': ['test-app1', 'test-app2', 'test-app3'],
-        'test_params': {
+        "apps_to_test": ["test-app1", "test-app2", "test-app3"],
+        "test_params": {
             "rate": 100,
             "loop_duration": 60,
             "replay_start_time": "2018-3-20-16-00",
@@ -29,20 +29,19 @@ def test_init_apps_from_test_params():
             "identifier": "qa",
         },
         "overrides": [],
-        'timezone': 'US/Pacific'
+        "timezone": "US/Pacific",
     }
 
     apps, test_params = orchestrator.init_apps_from_test_params(defaults)
     app1 = apps[0]
     app2 = App(
-        name='test-app1',
-        replay_start_time=MyTime().from_epoch(
-            epoch=1521586800, tzinfo='US/Pacific'),
+        name="test-app1",
+        replay_start_time=MyTime().from_epoch(epoch=1521586800, tzinfo="US/Pacific"),
         rate=100,
-        base_url='http://shadowreader.example.com',
-        identifier='qa',
+        base_url="http://shadowreader.example.com",
+        identifier="qa",
         loop_duration=60,
-        baseline=0
+        baseline=0,
     )
 
     assert app1 == app2 and len(apps) == 3
@@ -50,46 +49,74 @@ def test_init_apps_from_test_params():
 
 def test_init_apps_from_test_params_w_override():
     defaults = {
-        'apps_to_test': ['test-app1', 'test-app2'],
-        'test_params': {
+        "apps_to_test": ["test-app1", "test-app2"],
+        "test_params": {
             "rate": 100,
             "loop_duration": 60,
             "replay_start_time": "2018-3-20-16-00",
             "base_url": "http://shadowreader.example.com",
             "identifier": "qa",
         },
-        "overrides": [{
-            "app": "test-app1",
-            "rate": 50,
-            "loop_duration": 30,
-            "replay_start_time": "2018-3-20-17-00",
-            "base_url": "http://shadowreader.example.com",
-            "identifier": "qa",
-        }, {
-            "app": "test-app2",
-            "rate": 0,
-            "loop_duration": 30,
-            "replay_start_time": "2018-3-20-17-00",
-            "base_url": "http://shadowreader.example.com",
-            "identifier": "qa",
-        }],
-        'timezone':
-        'US/Pacific'
+        "overrides": [
+            {
+                "app": "test-app1",
+                "rate": 50,
+                "loop_duration": 30,
+                "replay_start_time": "2018-3-20-17-00",
+                "base_url": "http://shadowreader.example.com",
+                "identifier": "qa",
+            },
+            {
+                "app": "test-app2",
+                "rate": 0,
+                "loop_duration": 30,
+                "replay_start_time": "2018-3-20-17-00",
+                "base_url": "http://shadowreader.example.com",
+                "identifier": "qa",
+            },
+        ],
+        "timezone": "US/Pacific",
     }
 
     apps, test_params = orchestrator.init_apps_from_test_params(defaults)
     app1 = apps[0]
     app1_copy = App(
-        name='test-app1',
+        name="test-app1",
         replay_start_time=MyTime(epoch=1521590400),
         rate=50,
-        base_url='http://shadowreader.example.com',
-        identifier='qa',
+        base_url="http://shadowreader.example.com",
+        identifier="qa",
         loop_duration=30,
-        baseline=0
+        baseline=0,
     )
 
     assert app1 == app1_copy and len(apps) == 1
 
-if __name__ == '__main__':
-    test_init_apps_from_test_params()
+
+def test_init_apps_from_test_params_w_isoformat():
+    defaults = {
+        "apps_to_test": ["test-app1", "test-app2", "test-app3"],
+        "test_params": {
+            "rate": 100,
+            "loop_duration": 60,
+            "replay_start_time": "2018-08-02T00:30",
+            "base_url": "http://shadowreader.example.com",
+            "identifier": "qa",
+        },
+        "overrides": [],
+        "timezone": "US/Pacific",
+    }
+
+    apps, test_params = orchestrator.init_apps_from_test_params(defaults)
+    app1 = apps[0]
+    app2 = App(
+        name="test-app1",
+        replay_start_time=MyTime().from_epoch(epoch=1533195000, tzinfo="US/Pacific"),
+        rate=100,
+        base_url="http://shadowreader.example.com",
+        identifier="qa",
+        loop_duration=60,
+        baseline=0,
+    )
+    assert app1 == app2 and len(apps) == 3
+    assert app2.replay_start_time == app1.replay_start_time


### PR DESCRIPTION
This PR does:
1. Add support for datetime strings in ISO 8601 format.
2. Add unit tests for ISO formatted datetime strings.
