### PR TITLE
Introduce replay_end_time load test parameter to compliment replay_start_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ orchestrator-past:
     test_params: '{
                     "base_url": "http://www.mywebsite.com",
                     "rate": 100,
-                    "replay_start_time": "2018-08-06T13:30",
-                    "loop_duration": 60,
+                    "replay_start_time": "2018-08-06T01:00",
+                    "replay_end_time": "2018-08-06T02:00",
                     "identifier": "oss"
                 }'
     timezone: US/Pacific
@@ -69,15 +69,14 @@ orchestrator-past:
   #              It should not end with a "/"
   # "rate" - A percentage value at which ShadowReader will perform the load test.
   #          It accepts a float value larger than 0
-  # "replay_start_time" - ShadowReader replays traffic from certain time periods for its load tests.
+  # "replay_start_time" - ShadowReader replays traffic from a certain time window for its load tests.
   #                       This is the starting time for the replay period.
   #                       If ShadowReader has not collected data for this time period,
   #                       no requests will be sent in the load test.
-  # "loop_duration" - This is an integer value, denominated in minutes.
-  #                   It is how long the replay period will be, starting from the time specified in "replay_start_time"
-  #                   For example, if "replay_start_time" = "2018-08-06T13:30" and "loop_duration" = 60,
-  #                   then it will replay traffic from 2018-08-06T13:30 to 2018-08-06T14:30
-  #                   (ie. replay traffic from 2018-08-06 1:30PM to 2:30PM)
+  # "replay_end_time" - This is the end time for the replay time window.
+  #                     In the sample test_params above, the load test will replay traffic from
+  #                     2018-08-06 1AM to 2018-08-06 2AM
+  #                     The time windows are specified in ISO 8601 format.
   # "identifier" - This is an identifier that is used when tagging CloudWatch metrics. Editing it is optional.
   # "timezone" - Timezone the replay_start_time is in. Accepts pytz timezone names like "US/Pacific" or "UTC"
 ```

--- a/shadowreader/classes/exceptions.py
+++ b/shadowreader/classes/exceptions.py
@@ -17,3 +17,7 @@ limitations under the License.
 
 class InvalidLambdaEnvVarError(ValueError):
     pass
+
+
+class InvalidTestParametersError(ValueError):
+    pass

--- a/shadowreader/libs/validate.py
+++ b/shadowreader/libs/validate.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from pytz import timezone, all_timezones
 
-from classes.exceptions import InvalidLambdaEnvVarError
+from classes.exceptions import InvalidLambdaEnvVarError, InvalidTestParametersError
 from classes.mytime import MyTime
 
 
@@ -25,11 +25,13 @@ def validate_test_params(params: dict, tzinfo: timezone):
     if not params:
         return
 
-    required_params = ["rate", "loop_duration", "replay_start_time", "base_url"]
+    required_params = ["rate", "replay_start_time", "base_url"]
     for p in required_params:
         assert (
             p in params
         ), f"Required Lambda env var: {p} not found in test_params: {params}"
+
+    check_for_replay_window_params(params, tzinfo)
 
     rate = params["rate"]
     assert isinstance(rate, float) or isinstance(
@@ -37,15 +39,36 @@ def validate_test_params(params: dict, tzinfo: timezone):
     ), f"Rate must be an int or float"
     assert 0 <= rate, f"Test param rate: {rate} must be a float above 0"
 
-    loop_duration = params["loop_duration"]
-    assert isinstance(loop_duration, int), f"Loop duration must be an int"
-    assert 0 < loop_duration, f"Loop duration must be greater than 0"
 
+def check_for_replay_window_params(params: dict, tzinfo: timezone):
     replay_start_time = params["replay_start_time"]
-    replay_start_time = MyTime.set_to_replay_start_time_env_var(
-        replay_start_time, tzinfo
-    )
-    assert isinstance(replay_start_time, MyTime)
+
+    if "loop_duration" in params:
+        # Validate replay time window
+        loop_duration = params["loop_duration"]
+        assert isinstance(loop_duration, int), f"Loop duration must be an int"
+        assert 0 < loop_duration, f"Loop duration must be greater than 0"
+
+        replay_start_time = MyTime.set_to_replay_start_time_env_var(
+            replay_start_time, tzinfo
+        )
+        assert isinstance(replay_start_time, MyTime)
+    elif "replay_end_time" in params:
+        replay_start_time = MyTime.set_to_replay_start_time_env_var(
+            replay_start_time, tzinfo
+        )
+        replay_end_time = MyTime.set_to_replay_start_time_env_var(
+            params["replay_end_time"], tzinfo
+        )
+        if replay_start_time > replay_end_time:
+            raise InvalidTestParametersError(
+                "replay_end_time can not be after replay_start_time"
+            )
+
+    else:
+        raise InvalidTestParametersError(
+            "Must set either loop_duration or replay_end_time in test_params"
+        )
 
 
 def validate_timezone(tzinfo: str):

--- a/shadowreader/tests/unit/test_orchestrator.py
+++ b/shadowreader/tests/unit/test_orchestrator.py
@@ -121,3 +121,92 @@ def test_init_apps_from_test_params_w_isoformat():
     )
     assert app1 == app2 and len(apps) == 3
     assert app2.replay_start_time == app1.replay_start_time
+
+
+def test_init_apps_from_test_params_w_replay_end_time():
+    defaults = {
+        "apps_to_test": ["test-app1", "test-app2", "test-app3"],
+        "test_params": {
+            "rate": 100,
+            "replay_start_time": "2018-08-29T10:30",
+            "replay_end_time": "2018-08-30T12:31",
+            "base_url": "http://shadowreader.example.com",
+            "identifier": "qa",
+        },
+        "overrides": [],
+        "timezone": "Japan",
+    }
+
+    apps, test_params = orchestrator.init_apps_from_test_params(defaults)
+    app1 = apps[0]
+    app2 = App(
+        name="test-app1",
+        replay_start_time=MyTime(
+            year=2018, month=8, day=29, hour=10, minute=30, tzinfo="Japan"
+        ),
+        rate=100,
+        base_url="http://shadowreader.example.com",
+        identifier="qa",
+        loop_duration=1561,
+        baseline=0,
+    )
+
+    print(app1)
+    print(app2)
+    assert app1 == app2
+    assert len(apps) == 3
+    assert app2.replay_start_time == app1.replay_start_time
+
+
+def test_replay_window_w_replay_duration_of_1():
+    defaults = {
+        "apps_to_test": ["test-app1"],
+        "test_params": {
+            "rate": 100,
+            "replay_start_time": "2018-08-30T00:00",
+            "replay_end_time": "2018-08-30T00:00",
+            "base_url": "http://shadowreader.example.com",
+            "identifier": "qa",
+        },
+        "overrides": [],
+        "timezone": "Japan",
+    }
+
+    apps, test_params = orchestrator.init_apps_from_test_params(defaults)
+    app1 = apps[0]
+    assert app1.loop_duration == 1
+
+    defaults = {
+        "apps_to_test": ["test-app1"],
+        "test_params": {
+            "rate": 100,
+            "replay_start_time": "2018-08-30T00:00",
+            "replay_end_time": "2018-08-30T00:01",
+            "base_url": "http://shadowreader.example.com",
+            "identifier": "qa",
+        },
+        "overrides": [],
+        "timezone": "Japan",
+    }
+
+    apps, test_params = orchestrator.init_apps_from_test_params(defaults)
+    app1 = apps[0]
+    assert app1.loop_duration == 1
+
+
+def test_determine_replay_time_window():
+    params = {
+        "rate": 100,
+        "replay_start_time": "2018-08-30T00:00",
+        "replay_end_time": "2018-08-30T00:11",
+        "base_url": "http://shadowreader.example.com",
+        "identifier": "qa",
+    }
+    replay_duration, replay_start_time = orchestrator.determine_replay_time_window(
+        params, tzinfo="US/Eastern"
+    )
+    assert replay_duration == 11
+
+
+if __name__ == "__main__":
+    test_determine_replay_time_window()

--- a/shadowreader/tests/unit/test_orchestrator.py
+++ b/shadowreader/tests/unit/test_orchestrator.py
@@ -151,8 +151,6 @@ def test_init_apps_from_test_params_w_replay_end_time():
         baseline=0,
     )
 
-    print(app1)
-    print(app2)
     assert app1 == app2
     assert len(apps) == 3
     assert app2.replay_start_time == app1.replay_start_time


### PR DESCRIPTION
This resolves issue #18 

Currently the replay time window for a load test is specified using "replay_start_time" and "loop_duration"
This feature will allow a user to specify replay time window like so:

```
test_params: {
"replay_start_time": "2018-08-06T13:00",
"replay_end_time": "2018-08-06T14:00"
}
```
instead of:
```
test_params: {
"replay_start_time": "2018-08-06T13:00",
"loop_duration": 60
}
```