### PR TITLE
Add unit tests for ALB and CLB log parsing

### DIFF
--- a/shadowreader/plugins/alb.py
+++ b/shadowreader/plugins/alb.py
@@ -25,7 +25,6 @@ from libs.s3 import (
     fetch_file_names_on_s3,
 )
 from classes.mytime import MyTime
-from datetime import datetime
 from typing import Tuple, Match
 from collections import defaultdict
 
@@ -63,18 +62,16 @@ def _parse_line(line: Match[str]) -> dict:
     url = request[1]
     x = url.split("/")[3:]
     uri = f'/{"/".join(x)}'
-    user_agent = line.group("user_agent")
+
     timestamp = line.group("timestamp")  # timestamp in ISO format
-    timestamp = datetime.strptime(
-        timestamp[:19], "%Y-%m-%dT%H:%M:%S"
-    )  # convert to datetime obj
+    timestamp = MyTime._try_isoformat(timestamp, tzinfo="UTC").dt
 
     res = {
         "url": url,
         "uri": uri,
         "req_method": req_method,
         "timestamp": timestamp,
-        "user_agent": user_agent,
+        "user_agent": line.group("user_agent"),
     }
     return res
 

--- a/shadowreader/plugins/clb.py
+++ b/shadowreader/plugins/clb.py
@@ -24,7 +24,6 @@ from libs.s3 import (
     fetch_file_names_on_s3,
 )
 from classes.mytime import MyTime
-from datetime import datetime
 from typing import Tuple, Match
 from collections import defaultdict
 
@@ -65,9 +64,7 @@ def _parse_line(line: Match[str]) -> dict:
     uri = f'/{"/".join(x)}'
 
     timestamp = line.group("timestamp")  # timestamp in ISO format
-    timestamp = datetime.strptime(
-        timestamp[:19], "%Y-%m-%dT%H:%M:%S"
-    )  # convert to datetime obj
+    timestamp = MyTime._try_isoformat(timestamp, tzinfo="UTC").dt
 
     res = {
         "url": url,

--- a/shadowreader/tests/unit/test_alb.py
+++ b/shadowreader/tests/unit/test_alb.py
@@ -1,0 +1,45 @@
+"""
+Copyright 2018 Edmunds.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from plugins import alb
+
+
+def test_alb_log_parsing():
+    logs = [
+        'http 2018-09-18T00:15:00.391912Z app/SR-Demo-ALB/010d1e7cd31d5139 18.123.123.123:60138 - -1 -1 -1 200 - 245 192 "GET http://sr-demo-alb.elb.amazonaws.com:80/ HTTP/1.1" "python-requests/2.19.1" - - - "Root=1-5ba04384-d6fd7b802a5ec138a8cd9620" "-" "-" 0 2018-09-18T00:15:00.391000Z "fixed-response" "-"',
+        'http 2018-09-17T23:55:00.439945Z app/test123/31b04dcf954789b6 123.123.123.123:34936 123.123.132.81:17073 0.000 0.117 0.000 200 200 1590 39859 "GET http://www.testsite.com:80/zxcv/asda/24567/testme/test2 HTTP/1.0" "Mozilla/5.0 (Linux; Android 6.0.1; SM-T800 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36" - - arn:aws:elasticloadbalancing:us-east-1:12345:targetgroup/sr-demo/0bc8356a792940a6 "Root=1-5ba03e123124" "-" "-" 0 2018-09-17T23:55:00.319000Z "forward" "-"',
+        'http 2018-09-17T23:55:00.505420Z app/test123/31b04dcf954789b6 123.123.123.123:34868 123.123.133.226:17073 0.000 0.392 0.000 200 200 1315 43765 "GET http://www.testsite.com:80/asda/asd12/12345/?zxcv=1&vsda=true HTTP/1.0" "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" - - arn:aws:elasticloadbalancing:us-east-1:1234:targetgroup/sr-demo/0bc8356a792940a6 "Root=1-1123-asd1asd" "-" "-" 0 2018-09-17T23:55:00.109000Z "forward" "-"',
+        'http 2018-09-20T03:44:57.659531Z app/SR-Demo-ALB/010d1e7cd31d5139 123.123.248.213:42460 - -1 -1 -1 503 - 245 353 "GET http://sr-demo-alb-123.us-test-2.elb.amazonaws.com:80/test1234/abcd HTTP/1.1" "python-requests/2.19.1" - - arn:aws:elasticloadbalancing:us-east-2:1234:targetgroup/SrDemoTargetGroup/1234 "Root=1-124-124" "-" "-" 0 2018-09-20T03:44:57.659000Z "forward" "-"',
+    ]
+
+    logs = alb._regex_match_and_parse_logs(logs)
+
+    assert logs[0]["uri"] == "/zxcv/asda/24567/testme/test2"
+    assert logs[1]["uri"] == "/asda/asd12/12345/?zxcv=1&vsda=true"
+    assert logs[2]["uri"] == "/"
+    assert logs[3]["uri"] == "/test1234/abcd"
+
+    assert logs[0]["req_method"] == "GET"
+    assert logs[0]["timestamp"].timestamp() == 1537253700.0
+    assert logs[0]["timestamp"] < logs[3]["timestamp"]
+    assert (
+        logs[0]["user_agent"]
+        == "Mozilla/5.0 (Linux; Android 6.0.1; SM-T800 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36"
+    )
+
+
+if __name__ == "__main__":
+    test_alb_log_parsing()

--- a/shadowreader/tests/unit/test_alb.py
+++ b/shadowreader/tests/unit/test_alb.py
@@ -19,12 +19,11 @@ from plugins import alb
 
 def test_alb_log_parsing():
     logs = [
-        'http 2018-09-18T00:15:00.391912Z app/SR-Demo-ALB/010d1e7cd31d5139 18.123.123.123:60138 - -1 -1 -1 200 - 245 192 "GET http://sr-demo-alb.elb.amazonaws.com:80/ HTTP/1.1" "python-requests/2.19.1" - - - "Root=1-5ba04384-d6fd7b802a5ec138a8cd9620" "-" "-" 0 2018-09-18T00:15:00.391000Z "fixed-response" "-"',
-        'http 2018-09-17T23:55:00.439945Z app/test123/31b04dcf954789b6 123.123.123.123:34936 123.123.132.81:17073 0.000 0.117 0.000 200 200 1590 39859 "GET http://www.testsite.com:80/zxcv/asda/24567/testme/test2 HTTP/1.0" "Mozilla/5.0 (Linux; Android 6.0.1; SM-T800 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36" - - arn:aws:elasticloadbalancing:us-east-1:12345:targetgroup/sr-demo/0bc8356a792940a6 "Root=1-5ba03e123124" "-" "-" 0 2018-09-17T23:55:00.319000Z "forward" "-"',
         'http 2018-09-17T23:55:00.505420Z app/test123/31b04dcf954789b6 123.123.123.123:34868 123.123.133.226:17073 0.000 0.392 0.000 200 200 1315 43765 "GET http://www.testsite.com:80/asda/asd12/12345/?zxcv=1&vsda=true HTTP/1.0" "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" - - arn:aws:elasticloadbalancing:us-east-1:1234:targetgroup/sr-demo/0bc8356a792940a6 "Root=1-1123-asd1asd" "-" "-" 0 2018-09-17T23:55:00.109000Z "forward" "-"',
+        'http 2018-09-17T23:55:00.439945Z app/test123/31b04dcf954789b6 123.123.123.123:34936 123.123.132.81:17073 0.000 0.117 0.000 200 200 1590 39859 "GET http://www.testsite.com:80/zxcv/asda/24567/testme/test2 HTTP/1.0" "Mozilla/5.0 (Linux; Android 6.0.1; SM-T800 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36" - - arn:aws:elasticloadbalancing:us-east-1:12345:targetgroup/sr-demo/0bc8356a792940a6 "Root=1-5ba03e123124" "-" "-" 0 2018-09-17T23:55:00.319000Z "forward" "-"',
+        'http 2018-09-18T00:15:00.391912Z app/SR-Demo-ALB/010d1e7cd31d5139 18.123.123.123:60138 - -1 -1 -1 200 - 245 192 "GET http://sr-demo-alb.elb.amazonaws.com:80/ HTTP/1.1" "python-requests/2.19.1" - - - "Root=1-5ba04384-d6fd7b802a5ec138a8cd9620" "-" "-" 0 2018-09-18T00:15:00.391000Z "fixed-response" "-"',
         'http 2018-09-20T03:44:57.659531Z app/SR-Demo-ALB/010d1e7cd31d5139 123.123.248.213:42460 - -1 -1 -1 503 - 245 353 "GET http://sr-demo-alb-123.us-test-2.elb.amazonaws.com:80/test1234/abcd HTTP/1.1" "python-requests/2.19.1" - - arn:aws:elasticloadbalancing:us-east-2:1234:targetgroup/SrDemoTargetGroup/1234 "Root=1-124-124" "-" "-" 0 2018-09-20T03:44:57.659000Z "forward" "-"',
     ]
-
     logs = alb._regex_match_and_parse_logs(logs)
 
     assert logs[0]["uri"] == "/zxcv/asda/24567/testme/test2"
@@ -33,7 +32,7 @@ def test_alb_log_parsing():
     assert logs[3]["uri"] == "/test1234/abcd"
 
     assert logs[0]["req_method"] == "GET"
-    assert int(logs[0]["timestamp"].timestamp()) == 1537253700
+    assert logs[0]["timestamp"].timestamp() == 1537228500.0
     assert logs[0]["timestamp"] < logs[3]["timestamp"]
     assert (
         logs[0]["user_agent"]

--- a/shadowreader/tests/unit/test_alb.py
+++ b/shadowreader/tests/unit/test_alb.py
@@ -33,7 +33,7 @@ def test_alb_log_parsing():
     assert logs[3]["uri"] == "/test1234/abcd"
 
     assert logs[0]["req_method"] == "GET"
-    assert logs[0]["timestamp"].timestamp() == 1537253700.0
+    assert int(logs[0]["timestamp"].timestamp()) == 1537253700
     assert logs[0]["timestamp"] < logs[3]["timestamp"]
     assert (
         logs[0]["user_agent"]

--- a/shadowreader/tests/unit/test_clb.py
+++ b/shadowreader/tests/unit/test_clb.py
@@ -22,9 +22,8 @@ def test_clb_log_parsing():
         '2018-09-20T04:16:05.071375Z test-ELB 123.25.61.210:63407 123.123.15.138:902 0.000051 0.01047 0.00003 200 200 0 788 "GET https://sr.example.com:443/api/v1/asdf/sets/590045a1e4b1234599/abcdef/test123=zxc&zxc=abc&year=2018&type= HTTP/1.1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8" XXX-RSA-ZZZ-XXX-SHA256 TLSv1.2',
         '2018-09-20T04:16:05.924891Z test-ELB 123.255.254.192:19012 123.123.15.107:9051 0.00004 0.010085 0.000021 200 200 0 101 "GET http://sr.example.com:80/api/health/check HTTP/1.1" "Amazon-Route53-Health-Check-Service (ref 124-124-124-123-8f0e211dca04; report http://amzn.to/1vsZADi)" - -',
         '2018-09-20T04:16:06.473998Z qa-test-ELB 123.17.138.195:49928 123.123.15.107:9991 0.000063 0.012962 0.000023 200 200 0 861 "GET https://sr.example.com:443/example/abc/123419845935e4dc/test/xxx-search?xxx=1234&xxx=123&xxx=&xxx=&zzz=&xxx= HTTP/1.1" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36" XXX-RSA-ZZZ-XXX-SHA256 TLSv1.2',
-        '2018-09-20T04:16:06.473998Z qa-test-ELB 123.17.138.195:49928 123.123.15.107:9991 0.000063 0.012962 0.000023 200 200 0 861 "GET https://sr.example.com:443/ HTTP/1.1" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36" XXX-RSA-ZZZ-XXX-SHA256 TLSv1.2',
+        '2018-09-21T04:16:06.473998Z qa-test-ELB 123.17.138.195:49928 123.123.15.107:9991 0.000063 0.012962 0.000023 200 200 0 861 "GET https://sr.example.com:443/ HTTP/1.1" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36" XXX-RSA-ZZZ-XXX-SHA256 TLSv1.2',
     ]
-
     logs = clb._regex_match_and_parse_logs(logs)
 
     assert (
@@ -39,7 +38,7 @@ def test_clb_log_parsing():
     assert logs[3]["uri"] == "/"
 
     assert logs[0]["req_method"] == "GET"
-    assert int(logs[0]["timestamp"].timestamp()) == 1537442165
+    assert logs[0]["timestamp"].timestamp() == 1537416960.0
     assert logs[0]["timestamp"] < logs[3]["timestamp"]
     assert (
         logs[0]["user_agent"]

--- a/shadowreader/tests/unit/test_clb.py
+++ b/shadowreader/tests/unit/test_clb.py
@@ -1,0 +1,51 @@
+"""
+Copyright 2018 Edmunds.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from plugins import clb
+
+
+def test_clb_log_parsing():
+    logs = [
+        '2018-09-20T04:16:05.071375Z test-ELB 123.25.61.210:63407 123.123.15.138:902 0.000051 0.01047 0.00003 200 200 0 788 "GET https://sr.example.com:443/api/v1/asdf/sets/590045a1e4b1234599/abcdef/test123=zxc&zxc=abc&year=2018&type= HTTP/1.1" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8" XXX-RSA-ZZZ-XXX-SHA256 TLSv1.2',
+        '2018-09-20T04:16:05.924891Z test-ELB 123.255.254.192:19012 123.123.15.107:9051 0.00004 0.010085 0.000021 200 200 0 101 "GET http://sr.example.com:80/api/health/check HTTP/1.1" "Amazon-Route53-Health-Check-Service (ref 124-124-124-123-8f0e211dca04; report http://amzn.to/1vsZADi)" - -',
+        '2018-09-20T04:16:06.473998Z qa-test-ELB 123.17.138.195:49928 123.123.15.107:9991 0.000063 0.012962 0.000023 200 200 0 861 "GET https://sr.example.com:443/example/abc/123419845935e4dc/test/xxx-search?xxx=1234&xxx=123&xxx=&xxx=&zzz=&xxx= HTTP/1.1" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36" XXX-RSA-ZZZ-XXX-SHA256 TLSv1.2',
+        '2018-09-20T04:16:06.473998Z qa-test-ELB 123.17.138.195:49928 123.123.15.107:9991 0.000063 0.012962 0.000023 200 200 0 861 "GET https://sr.example.com:443/ HTTP/1.1" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36" XXX-RSA-ZZZ-XXX-SHA256 TLSv1.2',
+    ]
+
+    logs = clb._regex_match_and_parse_logs(logs)
+
+    assert (
+        logs[0]["uri"]
+        == "/api/v1/asdf/sets/590045a1e4b1234599/abcdef/test123=zxc&zxc=abc&year=2018&type="
+    )
+    assert logs[1]["uri"] == "/api/health/check"
+    assert (
+        logs[2]["uri"]
+        == "/example/abc/123419845935e4dc/test/xxx-search?xxx=1234&xxx=123&xxx=&xxx=&zzz=&xxx="
+    )
+    assert logs[3]["uri"] == "/"
+
+    assert logs[0]["req_method"] == "GET"
+    assert logs[0]["timestamp"].timestamp() == 1537442165.0
+    assert logs[0]["timestamp"] < logs[3]["timestamp"]
+    assert (
+        logs[0]["user_agent"]
+        == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8"
+    )
+
+
+if __name__ == "__main__":
+    test_clb_log_parsing()

--- a/shadowreader/tests/unit/test_clb.py
+++ b/shadowreader/tests/unit/test_clb.py
@@ -39,7 +39,7 @@ def test_clb_log_parsing():
     assert logs[3]["uri"] == "/"
 
     assert logs[0]["req_method"] == "GET"
-    assert logs[0]["timestamp"].timestamp() == 1537442165.0
+    assert int(logs[0]["timestamp"].timestamp()) == 1537442165
     assert logs[0]["timestamp"] < logs[3]["timestamp"]
     assert (
         logs[0]["user_agent"]


### PR DESCRIPTION
For issue #21 

Refactor parts of the access log parser code to be testing friendly and add accompanying tests to verify that CLB and ALB access logs are being parsed correctly using the supplied RegEx.
