### PR TITLE
Simplify Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,14 @@ install:
   - pip install -r shadowreader/requirements.txt
   
   # Set BRANCH to the name of the branch being built.
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  # - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   # Set REPO_SLUG to the name of the repo being built.
-  - export REPO_SLUG=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_REPO_SLUG; else echo $TRAVIS_PULL_REQUEST_SLUG; fi)
+  # - export REPO_SLUG=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_REPO_SLUG; else echo $TRAVIS_PULL_REQUEST_SLUG; fi)
   
   # Download necessary config file from the correct repository branch.
   # eg. If building branch "test123" for repo edmunds/shadowreader
   #     then it will download https://raw.githubusercontent.com/edmunds/shadowreader/test123/shadowreader/shadowreader.example.yml
-  - wget https://raw.githubusercontent.com/$REPO_SLUG/$BRANCH/shadowreader/shadowreader.example.yml --output-document=shadowreader.yml
-
+  # - wget https://raw.githubusercontent.com/$REPO_SLUG/$BRANCH/shadowreader/shadowreader.example.yml --output-document=shadowreader.yml
+  - cp shadowreader/shadowreader.example.yml shadowreader/shadowreader.yml
 script:
   - pytest shadowreader/tests/unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,16 +25,6 @@ env:
 
 install:
   - pip install -r shadowreader/requirements.txt
-  
-  # Set BRANCH to the name of the branch being built.
-  # - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  # Set REPO_SLUG to the name of the repo being built.
-  # - export REPO_SLUG=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_REPO_SLUG; else echo $TRAVIS_PULL_REQUEST_SLUG; fi)
-  
-  # Download necessary config file from the correct repository branch.
-  # eg. If building branch "test123" for repo edmunds/shadowreader
-  #     then it will download https://raw.githubusercontent.com/edmunds/shadowreader/test123/shadowreader/shadowreader.example.yml
-  # - wget https://raw.githubusercontent.com/$REPO_SLUG/$BRANCH/shadowreader/shadowreader.example.yml --output-document=shadowreader.yml
-  - cp shadowreader/shadowreader.example.yml shadowreader/shadowreader.yml
+  - cp shadowreader/shadowreader.example.yml shadowreader.yml
 script:
   - pytest shadowreader/tests/unit


### PR DESCRIPTION
Simplify build by just copying the example file over rather than downloading it from a specified GitHub branch.