### PR TITLE
Simplify configuration yaml files

### DIFF
--- a/shadowreader/serverless.example.yml
+++ b/shadowreader/serverless.example.yml
@@ -33,9 +33,6 @@ custom:
 
   parsed_data_bucket: ${self:custom.stack_name}-${self:custom.my_project_name}-parsed-data
 
-  consumer_master_past_name: ${self:custom.stack_name}-consumer-master-past
-  consumer_worker_name: ${self:custom.stack_name}-consumer-worker
-
 provider:
   name: aws
   runtime: python3.6
@@ -59,11 +56,7 @@ provider:
   environment:
     stage: ${self:custom.stage}
     region: ${self:custom.region}
-
     parsed_data_bucket: ${self:custom.parsed_data_bucket}
-
-    consumer_master_past_name: ${self:custom.consumer_master_past_name}
-    consumer_worker_name: ${self:custom.consumer_worker_name}
 
 # you can add packaging information here
 package:

--- a/shadowreader/shadowreader.example.yml
+++ b/shadowreader/shadowreader.example.yml
@@ -29,10 +29,6 @@ config:
   # The following variables must be set according to where your ELB logs are being written to
   access_logs_bucket: myelb-logs-bucket/AWSLogs/123456789/elasticloadbalancing/us-east-1/
   plugins_location: plugins
-  env_vars_to_get: [
-                       'region', 'stage', 'parsed_data_bucket',
-                       'consumer_master_past_name', 'consumer_worker_name'
-                   ]
   timeouts:
     init_timeout: 1 # Requests sent by the load test must establish a connection under this many seconds otherwise it will result in a timeout
     resp_timeout: 3 # Requests sent by the load test must return a response under this many seconds otherwise it will result in a timeout

--- a/shadowreader/utils/conf.py
+++ b/shadowreader/utils/conf.py
@@ -85,10 +85,7 @@ class Plugins:
 
     def _init_env_vars(self):
         """ Read the Lambda Environment variables and store it """
-        # env_vars_to_get = sr_config["env_vars_to_get"]
-        env_vars = {}
-        for env_var in REQUIRED_ENV_VARS:
-            env_vars[env_var] = getenv(env_var, "")
+        env_vars = {env_var: getenv(env_var) for env_var in REQUIRED_ENV_VARS}
 
         important_env_vars = ["region", "stage"]
         for env_var, val in env_vars.items():

--- a/shadowreader/utils/conf.py
+++ b/shadowreader/utils/conf.py
@@ -23,6 +23,8 @@ import traceback
 
 from classes.exceptions import InvalidLambdaEnvVarError
 
+REQUIRED_ENV_VARS = ["region", "stage", "parsed_data_bucket"]
+
 
 def load_yml_config(*, file: str, key: str) -> dict:
     """ Load shadowreader.yml file which specified configs for Shadowreader """
@@ -59,10 +61,14 @@ class Plugins:
             load all specified plugins and store configurations
         """
         sr_config = load_yml_config(file="shadowreader.yml", key="config")
-        self.env_vars = self._init_env_vars(sr_config)
+        self.env_vars = self._init_env_vars()
         self.sr_config = self._identify_keys_w_stage(sr_config, self.env_vars["stage"])
 
         self._sr_plugins = self._load_plugins()
+
+        stage = self.env_vars["stage"]
+        self.env_vars["consumer_master_past_name"] = f"sr-{stage}-consumer-master-past"
+        self.env_vars["consumer_worker_name"] = f"sr-{stage}-consumer-worker"
 
     def exists(self, plugin_name: str) -> bool:
         """ Check if a particular plugin was specified in the config"""
@@ -77,11 +83,11 @@ class Plugins:
         plugin = importlib.import_module(plugin_location)
         return plugin
 
-    def _init_env_vars(self, sr_config):
+    def _init_env_vars(self):
         """ Read the Lambda Environment variables and store it """
-        env_vars_to_get = sr_config["env_vars_to_get"]
+        # env_vars_to_get = sr_config["env_vars_to_get"]
         env_vars = {}
-        for env_var in env_vars_to_get:
+        for env_var in REQUIRED_ENV_VARS:
             env_vars[env_var] = getenv(env_var, "")
 
         important_env_vars = ["region", "stage"]


### PR DESCRIPTION
Simplify config files by removing `env_vars_to_get` from shadowreader.yml and moving consumer lambda names into conf.py file.